### PR TITLE
Fix master: Add consistent `alloc` prototype

### DIFF
--- a/a56.h
+++ b/a56.h
@@ -58,6 +58,8 @@ struct sym {
 
 extern int pass;
 
+char *alloc(int size);
+
 #define NEW(object) ((object *)alloc(sizeof(object)))
 
 #define MAX_NEST 20		/* maximum include file nesting */

--- a/subs.c
+++ b/subs.c
@@ -30,8 +30,6 @@ static char *Copyright = "Copyright (C) 1990-1994 Quinn C. Jensen";
 
 #define MAX 1024
 
-char *alloc();
-
 FILE *open_read(file)
 char *file;
 {
@@ -117,8 +115,7 @@ register int stops;
 	return o;
 }
 
-char *alloc(size)
-int size;
+char *alloc(int size)
 {
 	char *p = (char *)malloc(size);
 	if(NOT p)


### PR DESCRIPTION
This solves a crash during compilation with current master:

```
/bin/sh: line 1: 10068 Segmentation fault      (core dumped) /home/fox/Data/Projects/XboxDev/a56/keybld < a56.key > kparse.c
```

which is:

```
Program received signal SIGSEGV, Segmentation fault.
0x0000555555554c0f in add_tok (tok=0x555555756120 <buf> "X:", actions=0x555555756124 <buf+4> "{return XMEM;}") at keybld.c:77
77        unew->action = strsave(actions);
(gdb) print unew->action
Cannot access memory at address 0x55758680
```

where `unew` comes from `struct user_action *unew = (struct user_action *)alloc(sizeof *unew);`.

I'm not sure exactly why this doesn't work without the prototype, but I don't really care either, as long as it works.
I'll eventually do more changes to prevent similar issues.

---

For reference, I'm running Arch Linux x64 with these packages:

```
core/gcc 8.1.1+20180531-1 (base-devel)
    The GNU Compiler Collection - C and C++ frontends
core/gcc-libs 8.1.1+20180531-1 (base)
    Runtime libraries shipped by GCC
```