### PR TITLE
Support 'INC D' and 'DEC D'

### DIFF
--- a/a56.key
+++ b/a56.key
@@ -65,7 +65,9 @@ ASR		{return OP_ASR;}
 CLR		{return OP_CLR;}
 CMP		{return OP_CMP;}
 CMPM	{return OP_CMPM;}
+DEC		{return OP_DEC;}
 DIV		{return OP_DIV;}
+INC		{return OP_INC;}
 MAC		{return OP_MAC;}
 MACR	{return OP_MACR;}
 MPY		{return OP_MPY;}

--- a/a56.y
+++ b/a56.y
@@ -150,7 +150,9 @@ struct n sym_ref();
 %token OP_CLR
 %token OP_CMP
 %token OP_CMPM
+%token OP_DEC
 %token OP_DIV
+%token OP_INC
 %token OP_MAC
 %token OP_MACR
 %token OP_MPY
@@ -733,6 +735,10 @@ arith_inst
 			{w0 |= 0x0000F8 | (n2int($2) & 0xFF) << 8 | $4;}
 	|	and_op ix ',' funky_ctl_reg
 			{w0 |= 0x0000B8 | (n2int($2) & 0xFF) << 8 | $4;}
+	|	OP_DEC a_b
+			{w0 |= 0x00000A | $2;}
+	|	OP_INC a_b
+			{w0 |= 0x000008 | $2;}
 	;
 
 or_op	:	OP_OR


### PR DESCRIPTION
[Implemented as found in DSP56000 manuals](https://www.nxp.com/docs/en/reference-manual/DSP56000UM.pdf).

Tested using https://github.com/JayFoxRox/xbox-tools/pull/70 with following test setup:

```python
# Generate some test cases
sr = 0xC00310
inputs = (
  {'a2':0x00, 'a1': 0x001000, 'a0': 0xFFFFFF, 'b1': 0x10, 'sr': sr },
  {'a2':0x80, 'a1': 0x002000, 'a0': 0x000001, 'b1': 0x20, 'sr': sr },
  {'a2':0xFF, 'a1': 0x003000, 'a0': 0xFFFFFF, 'b1': 0x30, 'sr': sr }
)
processing = ['inc a'] * len(inputs)
outputs = [['a2','a1','a0','b1','sr']] * len(inputs)
tests = list(zip(inputs, processing, outputs))
```

More tests were done using 'inc b', 'dec a', 'dec b'.

Closes #8 