### PR TITLE
Fix compilation on MinGW

### DIFF
--- a/a56.y
+++ b/a56.y
@@ -1799,7 +1799,11 @@ expr
 
 #include <stdio.h>
 #include <setjmp.h>
+#ifdef _WIN32
+#include <signal.h>
+#else
 #include <sys/signal.h>
+#endif
 
 int yydebug;
 

--- a/getopt.c
+++ b/getopt.c
@@ -24,7 +24,6 @@ static	char	sccsfid[] = "@(#) getopt.c 5.0 (UTZoo) 1985";
 #define	ENDARGS  "--"
 
 /* this is included because index is not on some UNIX systems */
-static
 char *
 index (s, c)
 register	char	*s;


### PR DESCRIPTION
This allows a56 to be built and used on Windows.

Tested with MSYS2 MinGW and the default C toolchain on Ubuntu 18.04.1.